### PR TITLE
Fix laziness check in fix_lazy_images

### DIFF
--- a/src/moz_readability/mod.rs
+++ b/src/moz_readability/mod.rs
@@ -3160,6 +3160,7 @@ characters. For that reason, this <p> tag could not be a byline because it's too
                     <source media="(min-width:465px)" srcset="img_white_flower.jpg">
                     <img src="img_orange_flowers.jpg" alt="Flowers" style="width:auto;">
                 </picture>
+                <img id="no-lazy-class" src="https://image.url/" data-attrs="{&quot;src&quot;:&quot;https://other.url/1.png&quot;,&quot;alt&quot;:&quot;&quot;}"/>
             </body>
         </html>
         "#;
@@ -3188,6 +3189,13 @@ characters. For that reason, this <p> tag could not be a byline because it's too
         assert_eq!(
             lazy_loaded_attrs.get("data-src"),
             lazy_loaded_attrs.get("src")
+        );
+
+        let no_lazy_class = doc.root_node.select_first("#no-lazy-class").unwrap();
+        let no_lazy_class_attrs = no_lazy_class.attributes.borrow();
+        assert_eq!(
+            no_lazy_class_attrs.get("src").unwrap(),
+            "https://image.url/"
         );
     }
 

--- a/src/moz_readability/mod.rs
+++ b/src/moz_readability/mod.rs
@@ -1248,8 +1248,7 @@ impl Readability {
             let srcset = node_attr.get("srcset");
             let class = node_attr.get("class");
             if (src.is_some() || srcset.is_some())
-                && class.is_some()
-                && !class.unwrap().contains("lazy")
+                && class.and_then(|classname| classname.find("lazy")).is_none()
             {
                 continue;
             }


### PR DESCRIPTION
This PR changes how `fix_lazy_images` determines laziness: `img` nodes with `src` or `srcset` attributes but without `class` attribute are no longer considered lazy.

This is how [Readibility.js](https://github.com/mozilla/readability/blob/e1972362816cd47e679d1a4bbbf923a58b8a88d5/Readability.js#L1982) works, too.

The first commit is a failing testcase exercising laziness check, the second commit fixes #13.