### PR TITLE
 v0.6.1 release

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -164,7 +164,17 @@ impl<'a> TryFrom<ArgMatches<'a>> for AppConfig {
                     ExportType::EPUB
                 }
             })
-            .is_inlining_images(arg_matches.is_present("inline-images"))
+            .is_inlining_images(
+                (if arg_matches.is_present("inline-images") {
+                    if arg_matches.value_of("export") == Some("html") {
+                        Ok(true)
+                    } else {
+                        Err(Error::WrongExportInliningImages)
+                    }
+                } else {
+                    Ok(false)
+                })?,
+            )
             .try_init()
     }
 }

--- a/src/cli_config.yml
+++ b/src/cli_config.yml
@@ -12,7 +12,7 @@ args:
       long: file
       help: Input file containing links
       takes_value: true
-  - output_directory:
+  - output-directory:
       short: o
       long: output-dir
       help: Directory to store output epub documents
@@ -70,7 +70,6 @@ args:
       possible_values: [html, epub]
       value_name: type
       takes_value: true
-      default_value: epub
   - inline-images:
       long: inline-images
       help: Inlines the article images when exporting to HTML using base64. Pass --help to learn more.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -156,6 +156,8 @@ pub enum CliError<BuilderError: Debug + Display> {
     OutputDirectoryNotExists,
     #[error("Unable to start logger!\n{0}")]
     LogError(#[from] LogError),
-    #[error("The --inline-toc can only be used exporting to epub")]
+    #[error("The --inline-toc flag can only be used when exporting to epub")]
     WrongExportInliningToC,
+    #[error("The --inline-images flag can only be used when exporting to html")]
+    WrongExportInliningImages,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -138,6 +138,14 @@ pub enum LogError {
     CreateLogDirectoryError(#[from] std::io::Error),
 }
 
+// dumb hack to allow for comparing errors in testing.
+// derive macros cannot be used because underlying errors like io::Error do not derive PartialEq
+impl PartialEq for LogError {
+    fn eq(&self, other: &Self) -> bool {
+        format!("{:?}", self) == format!("{:?}", other)
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum CliError<BuilderError: Debug + Display> {
     #[error("Failed to open file with urls: {0}")]
@@ -160,4 +168,12 @@ pub enum CliError<BuilderError: Debug + Display> {
     WrongExportInliningToC,
     #[error("The --inline-images flag can only be used when exporting to html")]
     WrongExportInliningImages,
+}
+
+// dumb hack to allow for comparing errors in testing.
+// derive macros cannot be used because underlying errors like io::Error do not derive PartialEq
+impl<T: Debug + Display> PartialEq for CliError<T> {
+    fn eq(&self, other: &Self) -> bool {
+        format!("{:?}", self) == format!("{:?}", other)
+    }
 }

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -4,6 +4,7 @@ use kuchiki::{traits::*, NodeRef};
 use crate::errors::PaperoniError;
 use crate::moz_readability::{MetaData, Readability};
 
+/// A tuple of the url and an Option of the resource's MIME type
 pub type ResourceInfo = (String, Option<String>);
 
 pub struct Article {

--- a/src/http.rs
+++ b/src/http.rs
@@ -150,6 +150,15 @@ async fn process_img_response<'a>(
     let img_mime = img_response
         .content_type()
         .map(|mime| mime.essence().to_string());
+    if let Some(mime_str) = &img_mime {
+        if !mime_str.starts_with("image/") {
+            return Err(ErrorKind::HTTPError(format!(
+                "Invalid image MIME type: {} for {}",
+                mime_str, url
+            ))
+            .into());
+        }
+    }
     let img_ext = match img_response
         .content_type()
         .map(|mime| map_mime_subtype_to_ext(mime.subtype()).to_string())


### PR DESCRIPTION
This PR includes fixes for the following:
- displaying the help text when `paperoni` is passed with no args
- validation of the export type used when inlining images

Additionally, it includes more tests for the extractor and cli modules